### PR TITLE
Fix linting big files

### DIFF
--- a/src/tidy.ts
+++ b/src/tidy.ts
@@ -119,7 +119,7 @@ export function runClangTidy(
                     execFile(
                         clangTidy,
                         args,
-                        { cwd: workingDirectory },
+                        { cwd: workingDirectory, maxBuffer: 10 * 1024 * 1024 },
                         (error, stdout, stderr) => {
                             loggingChannel.appendLine(stdout);
                             loggingChannel.appendLine(stderr);


### PR DESCRIPTION
This PR increase the max buffer to store stdout of clang-tidy. It's resolve the YAML parser crashes on incomplete list of fixes